### PR TITLE
Use declarative webclient feign

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -137,6 +137,45 @@ public class ServiceInstanceApi {
 2. without eureka, the application need list all the service instances address  
 The ribbon will select one instance using different load balance rule  
 
+##Declarative webclient with feign
+1. Feign is a declarative web service client. It makes writing web service clients easier. To use Feign create an interface and annotate it. 
+2. Feign use ribbon and eureka under the hood for load balancing. **Spring Cloud integrates Ribbon and Eureka to provide a load balanced http client when using Feign.**
+
+```java
+//--------------enable feign client--------------
+@SpringBootApplication
+@EnableFeignClients //will scan feign client, can specify scan base packages
+@EnableDiscoveryClient
+public class UppercaseApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(UppercaseApplication.class);
+    }
+}
+//-----------------feign client------------------
+@FeignClient(name = "eureka-uppercase-service", qualifier = "uppercaseServiceFeignClient")
+public interface UppercaseServiceFeignClient {
+
+    @GetMapping(value = "api/uppercase")
+    String uppercase(@RequestParam(name = "name") String name);
+}
+
+//-------------------inject feign client to consumer----------
+@RestController
+@RequestMapping("api/uppercase")
+public class UppercaseAppApi {
+
+    @Autowired
+    @Qualifier("uppercaseServiceFeignClient")
+    private UppercaseServiceFeignClient uppercaseServiceFeignClient;
+
+    @GetMapping
+    public ResponseEntity<String> greeting(@RequestParam("name") String name) {
+        return ResponseEntity.ok().body("Greeting, " + uppercaseServiceFeignClient.uppercase(name));
+    }
+}
+
+```
 
 Issue: 
 # Q: Eureka Client application shutdown immediately after start up and registration?

--- a/uppercase-feign-with-eureka-app/build.gradle
+++ b/uppercase-feign-with-eureka-app/build.gradle
@@ -1,0 +1,4 @@
+dependencies{
+    compile 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    compile('org.springframework.cloud:spring-cloud-starter-openfeign')
+}

--- a/uppercase-feign-with-eureka-app/src/main/java/org/meng/cloud/app/UppercaseApplication.java
+++ b/uppercase-feign-with-eureka-app/src/main/java/org/meng/cloud/app/UppercaseApplication.java
@@ -1,0 +1,16 @@
+package org.meng.cloud.app;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
+@SpringBootApplication
+@EnableFeignClients //will scan feign client, can specify scan base packages
+@EnableDiscoveryClient
+public class UppercaseApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(UppercaseApplication.class);
+    }
+}

--- a/uppercase-feign-with-eureka-app/src/main/java/org/meng/cloud/app/api/UppercaseAppApi.java
+++ b/uppercase-feign-with-eureka-app/src/main/java/org/meng/cloud/app/api/UppercaseAppApi.java
@@ -1,0 +1,24 @@
+package org.meng.cloud.app.api;
+
+import org.meng.cloud.app.feign.UppercaseServiceFeignClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/uppercase")
+public class UppercaseAppApi {
+
+    @Autowired
+    @Qualifier("uppercaseServiceFeignClient")
+    private UppercaseServiceFeignClient uppercaseServiceFeignClient;
+
+    @GetMapping
+    public ResponseEntity<String> greeting(@RequestParam("name") String name) {
+        return ResponseEntity.ok().body("Greeting, " + uppercaseServiceFeignClient.uppercase(name));
+    }
+}

--- a/uppercase-feign-with-eureka-app/src/main/java/org/meng/cloud/app/feign/UppercaseServiceFeignClient.java
+++ b/uppercase-feign-with-eureka-app/src/main/java/org/meng/cloud/app/feign/UppercaseServiceFeignClient.java
@@ -1,0 +1,12 @@
+package org.meng.cloud.app.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "eureka-uppercase-service", qualifier = "uppercaseServiceFeignClient")
+public interface UppercaseServiceFeignClient {
+
+    @GetMapping(value = "api/uppercase")
+    String uppercase(@RequestParam(name = "name") String name);
+}

--- a/uppercase-feign-with-eureka-app/src/main/resources/application.yml
+++ b/uppercase-feign-with-eureka-app/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+logging:
+  level:
+    org.springframework: DEBUG
+    org.springframework.web: DEBUG
+    org.springframework.cloud: DEBUG
+    com.netflix: DEBUG
+    org.hibernate: DEBUG
+    org.meng.cloud: DEBUG

--- a/uppercase-feign-with-eureka-app/src/main/resources/bootstrap.yml
+++ b/uppercase-feign-with-eureka-app/src/main/resources/bootstrap.yml
@@ -1,0 +1,14 @@
+spring:
+  application:
+    name: uppercase-feign-with-eureka-app
+  cloud:
+    config:
+      enabled: false #don't fetch config from config server
+server:
+  port: 9812
+
+eureka:
+  client:
+    register-with-eureka: false
+    service-url:
+      defaultZone: http://eurekapeer0:8080/eureka,http://eurekapeer1:8081/eureka,http://eurekapeer2:8082/eureka


### PR DESCRIPTION
Feign is a declarative web service client. It makes writing web service clients easier. To use Feign create an interface and annotate it.
Spring Cloud integrates Ribbon and Eureka to provide a load balanced http client when using Feign.